### PR TITLE
Fix TypeError bug

### DIFF
--- a/point_e/diffusion/k_diffusion.py
+++ b/point_e/diffusion/k_diffusion.py
@@ -93,7 +93,7 @@ class GaussianToKarrasDenoiser:
         elif alpha_cumprod <= self.diffusion.alphas_cumprod[-1]:
             return self.diffusion.num_timesteps - 1
         else:
-            return float(self.alpha_cumprod_to_t(alpha_cumprod))
+            return int(self.alpha_cumprod_to_t(alpha_cumprod))
 
     def denoise(self, x_t, sigmas, clip_denoised=True, model_kwargs=None):
         t = th.tensor(


### PR DESCRIPTION
This fixes the bug `TypeError: 'float' object cannot be interpreted as an integer`, according to the fix described by [mjdi](https://github.com/mjdi) in [issue 6](https://github.com/openai/point-e/issues/6). I've tested it, and it works for me, at least.