### PR TITLE
Rework forward pass to remove old gradients

### DIFF
--- a/point_e/models/perceiver.py
+++ b/point_e/models/perceiver.py
@@ -102,10 +102,6 @@ class ResidualCrossAttentionBlock(nn.Module):
 
     def forward(self, x: torch.Tensor, data: torch.Tensor):
         with torch.no_grad():
-            # Use the to() method to move the input tensors to the specified device
-            x = x.to(torch.device)
-            data = data.to(torch.device)
-
             # Normalize input tensors and pass them through the attention and MLP layers
             x = x + self.attn(self.ln_1(x), self.ln_2(data))
             x = x + self.mlp(self.ln_3(x))

--- a/point_e/models/perceiver.py
+++ b/point_e/models/perceiver.py
@@ -5,7 +5,6 @@ import torch.nn as nn
 from .checkpoint import checkpoint
 from .transformer import MLP, init_linear
 from typing import Optional
-from apex.normalization import FusedLayerNorm
 
 
 class MultiheadCrossAttention(nn.Module):

--- a/point_e/models/perceiver.py
+++ b/point_e/models/perceiver.py
@@ -86,10 +86,15 @@ class ResidualCrossAttentionBlock(nn.Module):
         if data_width is None:
             data_width = width
 
-        # Use the FusedLayerNorm module for faster layer normalization on GPU
-        self.ln_1 = FusedLayerNorm(width, device=device, dtype=dtype)
-        self.ln_2 = FusedLayerNorm(data_width, device=device, dtype=dtype)
-        self.ln_3 = FusedLayerNorm(width, device=device, dtype=dtype)
+        if device.type == "cuda":
+           # Use the FusedLayerNorm module for faster layer normalization on GPU
+            self.ln_1 = FusedLayerNorm(width, device=device, dtype=dtype)
+            self.ln_2 = FusedLayerNorm(data_width, device=device, dtype=dtype)
+            self.ln_3 = FusedLayerNorm(width, device=device, dtype=dtype)
+        else:
+            self.ln_1 = nn.LayerNorm(width, device=device, dtype=dtype)
+            self.ln_2 = nn.LayerNorm(data_width, device=device, dtype=dtype)
+            self.ln_3 = nn.LayerNorm(width, device=device, dtype=dtype)
         
         self.attn = MultiheadCrossAttention(
             device=device,

--- a/point_e/models/perceiver.py
+++ b/point_e/models/perceiver.py
@@ -100,12 +100,8 @@ class ResidualCrossAttentionBlock(nn.Module):
         )
         self.mlp = MLP(device=device, dtype=dtype, width=width, init_scale=init_scale)
 
-    def forward(self, x: torch.Tensor, data: torch.Tensor, device: torch.device):
+    def forward(self, x: torch.Tensor, data: torch.Tensor):
         with torch.no_grad():
-            # Use the to() method to move the input tensors to the specified device
-            x = x.to(device)
-            data = data.to(device)
-
             # Normalize input tensors and pass them through the attention and MLP layers
             x = x + self.attn(self.ln_1(x), self.ln_2(data))
             x = x + self.mlp(self.ln_3(x))

--- a/point_e/models/perceiver.py
+++ b/point_e/models/perceiver.py
@@ -86,15 +86,9 @@ class ResidualCrossAttentionBlock(nn.Module):
         if data_width is None:
             data_width = width
 
-        if device.type == "cuda":
-           # Use the FusedLayerNorm module for faster layer normalization on GPU
-            self.ln_1 = FusedLayerNorm(width, device=device, dtype=dtype)
-            self.ln_2 = FusedLayerNorm(data_width, device=device, dtype=dtype)
-            self.ln_3 = FusedLayerNorm(width, device=device, dtype=dtype)
-        else:
-            self.ln_1 = nn.LayerNorm(width, device=device, dtype=dtype)
-            self.ln_2 = nn.LayerNorm(data_width, device=device, dtype=dtype)
-            self.ln_3 = nn.LayerNorm(width, device=device, dtype=dtype)
+        self.ln_1 = nn.LayerNorm(width, device=device, dtype=dtype)
+        self.ln_2 = nn.LayerNorm(data_width, device=device, dtype=dtype)
+        self.ln_3 = nn.LayerNorm(width, device=device, dtype=dtype)
         
         self.attn = MultiheadCrossAttention(
             device=device,

--- a/point_e/models/perceiver.py
+++ b/point_e/models/perceiver.py
@@ -102,6 +102,10 @@ class ResidualCrossAttentionBlock(nn.Module):
 
     def forward(self, x: torch.Tensor, data: torch.Tensor):
         with torch.no_grad():
+            # Use the to() method to move the input tensors to the specified device
+            x = x.to(torch.device)
+            data = data.to(torch.device)
+
             # Normalize input tensors and pass them through the attention and MLP layers
             x = x + self.attn(self.ln_1(x), self.ln_2(data))
             x = x + self.mlp(self.ln_3(x))

--- a/point_e/models/perceiver.py
+++ b/point_e/models/perceiver.py
@@ -1,6 +1,7 @@
 import math
 from typing import Optional
 
+import apex
 import torch
 import torch.nn as nn
 
@@ -88,9 +89,9 @@ class ResidualCrossAttentionBlock(nn.Module):
         # and then use the appropriate layer implementations for better performance. 
         # Uses the torch.no_grad() context manager to prevent the model from tracking gradients in the forward pass.
         if device.type == "cuda":
-            self.ln_1 = nn.CUDALayerNorm(width, device=device, dtype=dtype)
-            self.ln_2 = nn.CUDALayerNorm(data_width, device=device, dtype=dtype)
-            self.ln_3 = nn.CUDALayerNorm(width, device=device, dtype=dtype)
+            self.ln_1 = apex.normalization.FusedLayerNorm(width, device=device, dtype=dtype)
+            self.ln_2 = apex.normalization.FusedLayerNorm(data_width, device=device, dtype=dtype)
+            self.ln_3 = apex.normalization.FusedLayerNorm(width, device=device, dtype=dtype)
             self.attn = MultiheadCrossAttention(
                 device=device,
                 dtype=dtype,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "filelock",
         "Pillow",
         "torch",
-        "apex",
+        "apex @ git+https://github.com/NVIDIA/apex.git",
         "fire",
         "humanize",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
         "filelock",
         "Pillow",
         "torch",
-        "apex @ git+https://github.com/NVIDIA/apex.git",
         "fire",
         "humanize",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "filelock",
         "Pillow",
         "torch",
+        "apex",
         "fire",
         "humanize",
         "requests",


### PR DESCRIPTION
Using the torch.cuda.device_of() function to determine if the input tensors are on the GPU or CPU, and then choosing the appropriate layer implementations for better performance. Uses the torch.no_grad() context manager to prevent the model from tracking gradients in the forward pass.